### PR TITLE
お見積り情報入力画面で入力のバリデーション機能の改修

### DIFF
--- a/src/main/java/com/tiscon/controller/EstimateController.java
+++ b/src/main/java/com/tiscon/controller/EstimateController.java
@@ -75,10 +75,12 @@ public class EstimateController {
      * @return 遷移先
      */
     @PostMapping(value = "submit", params = "confirm")
-    String confirm(UserOrderForm userOrderForm, Model model) {
-
-        model.addAttribute("prefectures", estimateDAO.getAllPrefectures());
+    String confirm(@Validated  UserOrderForm userOrderForm, BindingResult result, Model model) {
         model.addAttribute("userOrderForm", userOrderForm);
+        model.addAttribute("prefectures", estimateDAO.getAllPrefectures());
+        if (result.hasErrors()) {
+            return "input";
+        }
         return "confirm";
     }
 

--- a/src/main/java/com/tiscon/form/UserOrderForm.java
+++ b/src/main/java/com/tiscon/form/UserOrderForm.java
@@ -5,6 +5,7 @@ import com.tiscon.validator.Numeric;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 /**
  * 顧客が入力する見積もり情報を保持するクラス。
@@ -17,6 +18,7 @@ public class UserOrderForm {
 
     @NotBlank
     @Numeric
+    @Size(min = 10, max = 11)
     private String tel;
 
     @Email
@@ -27,12 +29,14 @@ public class UserOrderForm {
     private String oldPrefectureId;
 
     @NotBlank
+    @Size(min = 1, max = 100)
     private String oldAddress;
 
     @NotBlank
     private String newPrefectureId;
 
     @NotBlank
+    @Size(min = 1, max = 100)
     private String newAddress;
 
     @Numeric

--- a/src/main/resources/templates/input.html
+++ b/src/main/resources/templates/input.html
@@ -25,7 +25,7 @@
           <span class="text-danger" th:if="${#fields.hasErrors('customerName')}"z th:errors="*{customerName}"></span>
         </div>
         <div class="form-group">
-          <label for="tel">連絡先TEL</label>
+          <label for="tel">連絡先TEL (半角数字のみ)</label>
           <input type="tel" id="tel" name="tel" th:field="*{tel}" class="form-control" value="03-1234-5678"/>
           <span class="text-danger" th:if="${#fields.hasErrors('tel')}" th:errors="*{tel}"></span>
         </div>
@@ -62,22 +62,22 @@
       <fieldset>
         <legend>荷物情報</legend>
         <div class="form-group">
-          <label for="box">段ボールの個数</label>
+          <label for="box">段ボールの個数 (半角数字のみ)</label>
           <input type="text" id="box" name="box" th:field="*{box}" class="form-control" value="10"/>
           <span class="text-danger" th:if="${#fields.hasErrors('box')}" th:errors="*{box}"></span>
         </div>
         <div class="form-group">
-          <label for="bed">ベッドの個数</label>
+          <label for="bed">ベッドの個数 (半角数字のみ)</label>
           <input type="text" id="bed" name="bed" th:field="*{bed}" class="form-control" value="3"/>
           <span class="text-danger" th:if="${#fields.hasErrors('bed')}" th:errors="*{bed}"></span>
         </div>
         <div class="form-group">
-          <label for="bicycle">自転車の個数</label>
+          <label for="bicycle">自転車の個数 (半角数字のみ)</label>
           <input type="text" id="bicycle" name="bicycle" th:field="*{bicycle}" class="form-control" value="1"/>
           <span class="text-danger" th:if="${#fields.hasErrors('bicycle')}" th:errors="*{bicycle}"></span>
         </div>
         <div class="form-group">
-          <label for="washingMachine">洗濯機の個数</label>
+          <label for="washingMachine">洗濯機の個数 (半角数字のみ)</label>
           <input type="text" id="washingMachine" name="washingMachine" th:field="*{washingMachine}" class="form-control"
                  value="1"/>
           <span class="text-danger" th:if="${#fields.hasErrors('washingMachine')}" th:errors="*{washingMachine}"></span>

--- a/src/main/resources/templates/input.html
+++ b/src/main/resources/templates/input.html
@@ -14,24 +14,25 @@
 <nav th:insert="header.html :: header"></nav>
 <div class="container">
   <form th:action="@{/submit}" th:object="${userOrderForm}" class="form-horizontal" method="post">
+    <span class="text-danger" th:if="${#fields.hasErrors('all')}">入力項目に誤りがあります</span>
     <h1>お見積り情報入力</h1>
-    <ul th:if="${#fields.hasErrors('all')}">
-      <li th:each="err : ${#fields.errors('all')}" th:text="${err}"></li>
-    </ul>
     <div class="col-sm-12">
       <fieldset>
         <legend>個人情報</legend>
         <div class="form-group">
           <label for="customerName">氏名</label>
           <input type="text" id="customerName" name="customerName" th:field="*{customerName}" class="form-control" value="山田太郎"/>
+          <span class="text-danger" th:if="${#fields.hasErrors('customerName')}"z th:errors="*{customerName}"></span>
         </div>
         <div class="form-group">
           <label for="tel">連絡先TEL</label>
           <input type="tel" id="tel" name="tel" th:field="*{tel}" class="form-control" value="03-1234-5678"/>
+          <span class="text-danger" th:if="${#fields.hasErrors('tel')}" th:errors="*{tel}"></span>
         </div>
         <div class="form-group">
           <label for="email">連絡先メールアドレス</label>
           <input type="text" id="email" name="email" th:field="*{email}" class="form-control" value="test@test.com"/>
+          <span class="text-danger" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></span>
         </div>
         <div class="form-group">
           <label for="oldPrefectureId">転居元住所（都道府県）</label>
@@ -43,6 +44,7 @@
           <label for="oldAddress">転居元住所（市区町村以下）</label>
           <input type="text" id="oldAddress" name="oldAddress" th:field="*{oldAddress}"
                  class="form-control" value="新宿区西新宿1-1-1"/>
+          <span class="text-danger" th:if="${#fields.hasErrors('oldAddress')}" th:errors="*{oldAddress}"></span>
         </div>
         <div class="form-group">
           <label for="newPrefectureId">転居先住所（都道府県）</label>
@@ -54,6 +56,7 @@
           <label for="newAddress">転居先住所（市区町村以下）</label>
           <input type="text" id="newAddress" name="newAddress" th:field="*{newAddress}" class="form-control"
                  value="札幌市南区1"/>
+          <span class="text-danger" th:if="${#fields.hasErrors('newAddress')}" th:errors="*{newAddress}"></span>
         </div>
       </fieldset>
       <fieldset>
@@ -61,19 +64,23 @@
         <div class="form-group">
           <label for="box">段ボールの個数</label>
           <input type="text" id="box" name="box" th:field="*{box}" class="form-control" value="10"/>
+          <span class="text-danger" th:if="${#fields.hasErrors('box')}" th:errors="*{box}"></span>
         </div>
         <div class="form-group">
           <label for="bed">ベッドの個数</label>
           <input type="text" id="bed" name="bed" th:field="*{bed}" class="form-control" value="3"/>
+          <span class="text-danger" th:if="${#fields.hasErrors('bed')}" th:errors="*{bed}"></span>
         </div>
         <div class="form-group">
           <label for="bicycle">自転車の個数</label>
           <input type="text" id="bicycle" name="bicycle" th:field="*{bicycle}" class="form-control" value="1"/>
+          <span class="text-danger" th:if="${#fields.hasErrors('bicycle')}" th:errors="*{bicycle}"></span>
         </div>
         <div class="form-group">
           <label for="washingMachine">洗濯機の個数</label>
           <input type="text" id="washingMachine" name="washingMachine" th:field="*{washingMachine}" class="form-control"
                  value="1"/>
+          <span class="text-danger" th:if="${#fields.hasErrors('washingMachine')}" th:errors="*{washingMachine}"></span>
         </div>
         <div class="form-group">
           <label for="hasWashingMachineSettingOption">洗濯機の設置工事申し込み</label>


### PR DESCRIPTION
* 内容
  * 入力欄に不備があった場合に、該当の入力欄の近くにエラーが表示されるように修正
  * 電話番号の文字列長を10文字or11文字に制限
  * 住所（市町村以下）の文字列長を1〜100文字に制限
  * 半角数字のみを受け付ける入力欄には、「半角数字のみ」という文言を追加

* 場所
お見積り情報入力画面