### PR TITLE
ダンボールやその他の荷物の数に大きな数を指定するとエラーが出る

### DIFF
--- a/src/main/java/com/tiscon/dao/EstimateDao.java
+++ b/src/main/java/com/tiscon/dao/EstimateDao.java
@@ -123,6 +123,17 @@ public class EstimateDao {
     }
 
     /**
+     * トラック積載量テーブルに登録されているすべてのトラック積載量を取得する。
+     *
+     * @return すべてのトラック積載量
+     */
+    public List<TruckCapacity> getAllTruckCapacity() {
+        String sql = "SELECT * FROM TRUCK_CAPACITY";
+        return parameterJdbcTemplate.query(sql,
+                BeanPropertyRowMapper.newInstance(TruckCapacity.class));
+    }
+
+    /**
      * 段ボール数に応じたトラック料金を取得する。
      *
      * @param boxNum 総段ボール数

--- a/src/main/java/com/tiscon/domain/TruckCapacity.java
+++ b/src/main/java/com/tiscon/domain/TruckCapacity.java
@@ -1,0 +1,29 @@
+package com.tiscon.domain;
+
+import java.io.Serializable;
+
+public class TruckCapacity implements Serializable {
+    private String truckId;
+
+    private String truckType;
+
+    private String maxBox;
+
+    private String price;
+
+    public String getTruckId() { return truckId; }
+
+    public void setTruckId(String truckId) { this.truckId = truckId; }
+
+    public String getTruckType() { return truckType; }
+
+    public void setTruckType(String truckType) { this.truckType = truckType; }
+
+    public String getMaxBox() { return maxBox; }
+
+    public void setMaxBox(String maxBox) { this.maxBox = maxBox; }
+
+    public String getPrice() { return price; }
+
+    public void setPrice(String price) { this.price = price; }
+}


### PR DESCRIPTION
* 内容
ダンボールの総計が200より多い場合にエラーが発生して見積もりが算出できなかったので修正

* 場所
「概算お見積り結果」画面